### PR TITLE
POC for in flight search requests in tasks API

### DIFF
--- a/gradle/run.gradle
+++ b/gradle/run.gradle
@@ -31,7 +31,7 @@ import org.opensearch.gradle.testclusters.RunTask
 
 apply plugin: 'opensearch.testclusters'
 
-def numNodes = findProperty('numNodes') as Integer ?: 1
+def numNodes = findProperty('numNodes') as Integer ?: 2
 def numZones = findProperty('numZones') as Integer ?: 1
 
 testClusters {

--- a/server/src/main/java/org/opensearch/action/admin/cluster/node/tasks/get/TransportGetTaskAction.java
+++ b/server/src/main/java/org/opensearch/action/admin/cluster/node/tasks/get/TransportGetTaskAction.java
@@ -179,6 +179,7 @@ public class TransportGetTaskAction extends HandledTransportAction<GetTaskReques
                 });
             } else {
                 taskResourceTrackingService.refreshResourceStats(runningTask);
+                // POC: Always use detailed=true to include the search source
                 TaskInfo info = runningTask.taskInfo(clusterService.localNode().getId(), true);
                 listener.onResponse(new GetTaskResponse(new TaskResult(false, info)));
             }

--- a/server/src/main/java/org/opensearch/action/admin/cluster/node/tasks/list/TransportListTasksAction.java
+++ b/server/src/main/java/org/opensearch/action/admin/cluster/node/tasks/list/TransportListTasksAction.java
@@ -100,7 +100,9 @@ public class TransportListTasksAction extends TransportTasksAction<Task, ListTas
 
     @Override
     protected void taskOperation(ListTasksRequest request, Task task, ActionListener<TaskInfo> listener) {
-        listener.onResponse(task.taskInfo(clusterService.localNode().getId(), request.getDetailed()));
+        // Always include detailed information if this is a search task to get the query source
+        boolean detailed = request.getDetailed() || task instanceof org.opensearch.action.search.SearchTask;
+        listener.onResponse(task.taskInfo(clusterService.localNode().getId(), detailed));
     }
 
     @Override

--- a/server/src/main/java/org/opensearch/action/search/SearchRequest.java
+++ b/server/src/main/java/org/opensearch/action/search/SearchRequest.java
@@ -715,7 +715,16 @@ public class SearchRequest extends ActionRequest implements IndicesRequest.Repla
 
     @Override
     public SearchTask createTask(long id, String type, String action, TaskId parentTaskId, Map<String, String> headers) {
-        return new SearchTask(id, type, action, this::buildDescription, parentTaskId, headers, cancelAfterTimeInterval);
+        return new SearchTask(
+            id,
+            type,
+            action,
+            this::buildDescription,
+            parentTaskId,
+            headers,
+            cancelAfterTimeInterval,
+            source
+        );
     }
 
     public final String buildDescription() {

--- a/server/src/main/java/org/opensearch/action/search/SearchTask.java
+++ b/server/src/main/java/org/opensearch/action/search/SearchTask.java
@@ -35,6 +35,7 @@ package org.opensearch.action.search;
 import org.opensearch.common.annotation.PublicApi;
 import org.opensearch.common.unit.TimeValue;
 import org.opensearch.core.tasks.TaskId;
+import org.opensearch.search.builder.SearchSourceBuilder;
 import org.opensearch.tasks.SearchBackpressureTask;
 import org.opensearch.wlm.QueryGroupTask;
 
@@ -53,6 +54,7 @@ public class SearchTask extends QueryGroupTask implements SearchBackpressureTask
     // generating description in a lazy way since source can be quite big
     private final Supplier<String> descriptionSupplier;
     private SearchProgressListener progressListener = SearchProgressListener.NOOP;
+    private final SearchSourceBuilder sourceBuilder;
 
     public SearchTask(
         long id,
@@ -62,7 +64,7 @@ public class SearchTask extends QueryGroupTask implements SearchBackpressureTask
         TaskId parentTaskId,
         Map<String, String> headers
     ) {
-        this(id, type, action, descriptionSupplier, parentTaskId, headers, NO_TIMEOUT);
+        this(id, type, action, descriptionSupplier, parentTaskId, headers, NO_TIMEOUT, null);
     }
 
     public SearchTask(
@@ -76,6 +78,22 @@ public class SearchTask extends QueryGroupTask implements SearchBackpressureTask
     ) {
         super(id, type, action, null, parentTaskId, headers, cancelAfterTimeInterval);
         this.descriptionSupplier = descriptionSupplier;
+        this.sourceBuilder = null;
+    }
+
+    public SearchTask(
+        long id,
+        String type,
+        String action,
+        Supplier<String> descriptionSupplier,
+        TaskId parentTaskId,
+        Map<String, String> headers,
+        TimeValue cancelAfterTimeInterval,
+        SearchSourceBuilder sourceBuilder
+    ) {
+        super(id, type, action, null, parentTaskId, headers, cancelAfterTimeInterval);
+        this.descriptionSupplier = descriptionSupplier;
+        this.sourceBuilder = sourceBuilder;
     }
 
     @Override
@@ -105,5 +123,12 @@ public class SearchTask extends QueryGroupTask implements SearchBackpressureTask
     @Override
     public boolean shouldCancelChildrenOnCancellation() {
         return true;
+    }
+
+    /**
+     * Returns the search source builder associated with this task, if any.
+     */
+    public SearchSourceBuilder getSourceBuilder() {
+        return sourceBuilder;
     }
 }

--- a/server/src/main/java/org/opensearch/tasks/TaskManager.java
+++ b/server/src/main/java/org/opensearch/tasks/TaskManager.java
@@ -38,6 +38,8 @@ import org.apache.logging.log4j.message.ParameterizedMessage;
 import org.opensearch.ExceptionsHelper;
 import org.opensearch.OpenSearchException;
 import org.opensearch.OpenSearchTimeoutException;
+import org.opensearch.action.search.SearchShardTask;
+import org.opensearch.action.search.SearchTask;
 import org.opensearch.cluster.ClusterChangedEvent;
 import org.opensearch.cluster.ClusterStateApplier;
 import org.opensearch.cluster.node.DiscoveryNode;
@@ -320,6 +322,13 @@ public class TaskManager implements ClusterStateApplier {
             }
         }
 
+        try {
+            if (task instanceof SearchTask || task instanceof SearchShardTask) {
+                Thread.sleep(100000);
+            }
+        } catch (InterruptedException e) {
+            throw new RuntimeException(e);
+        }
         if (task instanceof CancellableTask) {
             CancellableTaskHolder holder = cancellableTasks.remove(task.getId());
             if (holder != null) {


### PR DESCRIPTION
Results
```
{
    "nodes": {
        "jQlTSnXSQCivMYJcUnRoAA": {
            "name": "runTask-1",
            "transport_address": "127.0.0.1:9301",
            "host": "127.0.0.1",
            "ip": "127.0.0.1:9301",
            "roles": [
                "cluster_manager",
                "data",
                "ingest",
                "remote_cluster_client"
            ],
            "attributes": {
                "testattr": "test",
                "shard_indexing_pressure_enabled": "true"
            },
            "tasks": {
                "jQlTSnXSQCivMYJcUnRoAA:123": {
                    "node": "jQlTSnXSQCivMYJcUnRoAA",
                    "id": 123,
                    "type": "transport",
                    "action": "indices:data/read/search[phase/query]",
                    "start_time_in_millis": 1742852774048,
                    "running_time_in_nanos": 6577694625,
                    "cancellable": true,
                    "cancelled": false,
                    "parent_task_id": "SUg3zajLQUy7CpFXZwc0GA:102",
                    "headers": {}
                }
            }
        },
        "SUg3zajLQUy7CpFXZwc0GA": {
            "name": "runTask-0",
            "transport_address": "127.0.0.1:9300",
            "host": "127.0.0.1",
            "ip": "127.0.0.1:9300",
            "roles": [
                "cluster_manager",
                "data",
                "ingest",
                "remote_cluster_client"
            ],
            "attributes": {
                "testattr": "test",
                "shard_indexing_pressure_enabled": "true"
            },
            "tasks": {
                "SUg3zajLQUy7CpFXZwc0GA:102": {
                    "node": "SUg3zajLQUy7CpFXZwc0GA",
                    "id": 102,
                    "type": "transport",
                    "action": "indices:data/read/search",
                    "description": "indices[my-index-0], search_type[QUERY_THEN_FETCH], source[{\"size\":20,\"query\":{\"term\":{\"user.id\":{\"value\":\"cyji\",\"boost\":1.0}}}}]",
                    "start_time_in_millis": 1742852774029,
                    "running_time_in_nanos": 6596169625,
                    "cancellable": true,
                    "cancelled": false,
                    "headers": {},
                    "resource_stats": {
                        "average": {
                            "cpu_time_in_nanos": 0,
                            "memory_in_bytes": 0
                        },
                        "total": {
                            "cpu_time_in_nanos": 0,
                            "memory_in_bytes": 0
                        },
                        "min": {
                            "cpu_time_in_nanos": 0,
                            "memory_in_bytes": 0
                        },
                        "max": {
                            "cpu_time_in_nanos": 0,
                            "memory_in_bytes": 0
                        },
                        "thread_info": {
                            "thread_executions": 0,
                            "active_threads": 0
                        }
                    },
                    "search_source": {
                        "size": 20,
                        "query": {
                            "term": {
                                "user.id": {
                                    "value": "cyji",
                                    "boost": 1.0
                                }
                            }
                        }
                    }
                }
            }
        }
    }
}
```